### PR TITLE
Improved type checking when setting cell values

### DIFF
--- a/OpenXmlPowerTools.sln
+++ b/OpenXmlPowerTools.sln
@@ -84,6 +84,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MarkupSimplifierApp", "OpenXmlPowerToolsExamples\MarkupSimplifierApp\MarkupSimplifierApp.csproj", "{6731E031-9C81-48FB-97A7-0E945993BCE2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemorySpreadsheet01", "OpenXmlPowerToolsExamples\MemorySpreadsheet01\MemorySpreadsheet01.csproj", "{E4F1BE6C-2366-469A-8ADE-8DA2CDC012FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -230,6 +232,10 @@ Global
 		{6731E031-9C81-48FB-97A7-0E945993BCE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6731E031-9C81-48FB-97A7-0E945993BCE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6731E031-9C81-48FB-97A7-0E945993BCE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4F1BE6C-2366-469A-8ADE-8DA2CDC012FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4F1BE6C-2366-469A-8ADE-8DA2CDC012FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4F1BE6C-2366-469A-8ADE-8DA2CDC012FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4F1BE6C-2366-469A-8ADE-8DA2CDC012FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -268,6 +274,7 @@ Global
 		{C9CAA69C-575A-442E-9D8A-69C53B39D72C} = {A83D6B58-6D38-46AF-8C20-5CFC170A1063}
 		{3D1C46E1-7A9E-4A4B-8D95-68613603DEDF} = {A83D6B58-6D38-46AF-8C20-5CFC170A1063}
 		{6731E031-9C81-48FB-97A7-0E945993BCE2} = {A83D6B58-6D38-46AF-8C20-5CFC170A1063}
+		{E4F1BE6C-2366-469A-8ADE-8DA2CDC012FE} = {A83D6B58-6D38-46AF-8C20-5CFC170A1063}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E623EFF5-2CA4-4FA0-B3AB-53F921DA212E}

--- a/OpenXmlPowerTools/WorksheetAccessor.cs
+++ b/OpenXmlPowerTools/WorksheetAccessor.cs
@@ -148,22 +148,32 @@ namespace Codeuctivity.OpenXmlPowerTools
             var cellReference = WorksheetAccessor.GetColumnId(column) + row.ToString();
             XElement? newCell = null;
 
-            if (cellValue is int || cellValue is double)
+            if (cellValue is sbyte
+                || cellValue is byte
+                || cellValue is short
+                || cellValue is ushort
+                || cellValue is int
+                || cellValue is uint
+                || cellValue is long
+                || cellValue is ulong
+                || cellValue is float
+                || cellValue is double
+                || cellValue is decimal)
             {
-                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XElement(S.v, cellValue.ToString()));
+                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "n"), new XElement(S.v, cellValue.ToString()));
             }
             else if (cellValue is bool)
             {
                 newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "b"), new XElement(S.v, (bool)cellValue ? "1" : "0"));
             }
-            else if (cellValue is string)
+            else if (cellValue is DateTime)
             {
-                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "inlineStr"),
-                    new XElement(S._is, new XElement(S.t, cellValue.ToString())));
+                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XElement(S.v, ((DateTime)cellValue).ToOADate().ToString()));
+                if (styleIndex == 0) newCell.Add(new XAttribute(NoNamespace.s, "1")); // add default datetime style (as defined in defaultStyle)
             }
-            if (newCell == null)
+            else // everything else is treated as string
             {
-                throw new ArgumentException("Invalid cell type.");
+                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "inlineStr"), new XElement(S._is, new XElement(S.t, cellValue.ToString())));
             }
 
             if (styleIndex != 0)
@@ -298,30 +308,43 @@ namespace Codeuctivity.OpenXmlPowerTools
             return rowElement.Elements(S.c).FirstOrDefault(c => c.Attribute(NoNamespace.r).Value.Equals(cellReference));
         }
 
-        // Sets the value for the specified cell
-        // The "value" must be double/Double, int/Int32, bool/Boolean or string/String type
-        public static void SetCellValue(WorksheetPart worksheet, int row, int column, object value)
+        // Sets the value for the specified cell (with option to select style)
+        public static void SetCellValue(WorksheetPart worksheet, int row, int column, object value, int styleIndex = 0)
         {
             var worksheetXDocument = worksheet.GetXDocument();
             var cellReference = GetColumnId(column) + row.ToString();
             XElement? newCell = null;
 
-            if (value is int || value is double)
+            if (value is sbyte
+                || value is byte
+                || value is short
+                || value is ushort
+                || value is int
+                || value is uint
+                || value is long
+                || value is ulong
+                || value is float
+                || value is double
+                || value is decimal)
             {
-                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XElement(S.v, value.ToString()));
+                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "n"), new XElement(S.v, value.ToString()));
             }
             else if (value is bool)
             {
                 newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "b"), new XElement(S.v, (bool)value ? "1" : "0"));
             }
-            else if (value is string)
+            else if (value is DateTime)
             {
-                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "inlineStr"),
-                    new XElement(S._is, new XElement(S.t, value.ToString())));
+                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XElement(S.v, ((DateTime)value).ToOADate().ToString()));
             }
-            if (newCell == null)
+            else // everything else is treated as string
             {
-                throw new ArgumentException("Invalid cell type.");
+                newCell = new XElement(S.c, new XAttribute(NoNamespace.r, cellReference), new XAttribute(NoNamespace.t, "inlineStr"), new XElement(S._is, new XElement(S.t, value.ToString())));
+            }
+
+            if (styleIndex != 0)
+            {
+                newCell.Add(new XAttribute(NoNamespace.s, styleIndex));
             }
 
             SetCell(worksheetXDocument, newCell);
@@ -2243,8 +2266,9 @@ namespace Codeuctivity.OpenXmlPowerTools
     <xf numFmtId='0' fontId='1' fillId='31' borderId='0' applyNumberFormat='0' applyBorder='0' applyAlignment='0' applyProtection='0'/>
     <xf numFmtId='0' fontId='17' fillId='32' borderId='0' applyNumberFormat='0' applyBorder='0' applyAlignment='0' applyProtection='0'/>
   </cellStyleXfs>
-  <cellXfs count='1'>
+  <cellXfs count='2'>
     <xf numFmtId='0' fontId='0' fillId='0' borderId='0' xfId='0'/>
+    <xf numFmtId='22' fontId='0' fillId='0' borderId='0' xfId='0' applyNumberFormat='1'/>
   </cellXfs>
   <cellStyles count='42'>
     <cellStyle name='20% - Accent1' xfId='19' builtinId='30' customBuiltin='1'/>

--- a/OpenXmlPowerToolsExamples/MemorySpreadsheet01/MemorySpreadsheet01.cs
+++ b/OpenXmlPowerToolsExamples/MemorySpreadsheet01/MemorySpreadsheet01.cs
@@ -1,0 +1,67 @@
+﻿using DocumentFormat.OpenXml.Packaging;
+using Codeuctivity.OpenXmlPowerTools;
+using System;
+using System.Data;
+using System.IO;
+
+namespace MemorySpreadsheet01
+{
+    internal class MemorySpreadsheetExample
+    {
+        private static void Main(string[] args)
+        {
+            var n = DateTime.Now;
+            var tempDi = new DirectoryInfo(string.Format("ExampleOutput-{0:00}-{1:00}-{2:00}-{3:00}{4:00}{5:00}", n.Year - 2000, n.Month, n.Day, n.Hour, n.Minute, n.Second));
+            tempDi.Create();
+
+            DataTable d = new DataTable();
+            d.Columns.Add("String", typeof(String));
+            d.Columns.Add("DateTime", typeof(DateTime));
+            d.Columns.Add("Bool", typeof(bool));
+            d.Columns.Add("Integer", typeof(Int32));
+            d.Columns.Add("Float", typeof(float));
+            d.Columns.Add("Double", typeof(double));
+            d.Columns.Add("Decimal", typeof(decimal));
+
+            d.Rows.Add("Date", new DateTime(2021, 6, 29), true, (Int32)42, 5.93F, Math.PI, (decimal)4.99);
+            d.Rows.Add("Date and Time", new DateTime(2020, 10, 01, 13, 55, 1), false);
+
+            MemoryStream stream = new MemoryStream();
+            using (OpenXmlMemoryStreamDocument streamDoc = OpenXmlMemoryStreamDocument.CreateSpreadsheetDocument())
+            {
+                using (SpreadsheetDocument doc = streamDoc.GetSpreadsheetDocument())
+                {
+                    string sheetName = "Test";
+                    WorksheetAccessor.CreateDefaultStyles(doc);
+                    WorksheetPart sheet = WorksheetAccessor.AddWorksheet(doc, sheetName);
+                    MemorySpreadsheet ms = new MemorySpreadsheet();
+
+                    for (int h = 0; h < d.Columns.Count; h++)
+                    {
+                        ms.SetCellValue(1, h + 1, d.Columns[h].ColumnName, WorksheetAccessor.GetStyleIndex(doc, "Total"));
+                    }
+
+                    int rowIndex = 2;
+                    foreach (DataRow row in d.Rows)
+                    {
+                        for (int c = 0; c < d.Columns.Count; c++)
+                        {
+                            ms.SetCellValue(rowIndex, c + 1, row[c]);
+                        }
+                        rowIndex++;
+                    }
+
+                    WorksheetAccessor.SetSheetContents(sheet, ms);
+                }
+
+                streamDoc.GetModifiedSmlDocument().WriteByteArray(stream);
+                stream.Position = 0;
+            }
+
+            FileStream file = new FileStream(Path.Combine(tempDi.FullName, "Test1.xlsx"), FileMode.Create, FileAccess.Write);
+            stream.WriteTo(file);
+            file.Close();
+            stream.Close();
+        }
+    }
+}

--- a/OpenXmlPowerToolsExamples/MemorySpreadsheet01/MemorySpreadsheet01.csproj
+++ b/OpenXmlPowerToolsExamples/MemorySpreadsheet01/MemorySpreadsheet01.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenXmlPowerTools\OpenXmlPowerTools.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
**Changes to WorksheetAccessor.cs**

Updated GetElements and SetCellValue to allow any types and not just int, double, bool or string.
This change eliminates the 'Invalid Cell Type' error.
Proper handling of datetime type required an appropriate number format to be added to the default formats XML.

_An example project has been included to demonstrate the functionality._