### PR TITLE
Fix tests in WmlToHtmlConverterTests never failing

### DIFF
--- a/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
@@ -194,7 +194,7 @@ namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
                     Assert.Fail($"Expected PixelErrorCount beyond {allowedPixelErrorCount} but was {result.PixelErrorCount}\nExpected {expectFullPath}\ndiffers to actual {actualFullPath}\n Diff is {newDiffImage} \nReplace {actualFullPath} with the new value or store the diff as {allowedDiffImage}.");
                 }
             }
-            catch
+            catch (System.Exception ex) when (!(ex is Xunit.Sdk.FailException))
             {
                 SaveToGithubActionsPickupTestresultsDirectory(actualFullPath, expectFullPath);
             }


### PR DESCRIPTION
`Assert.Fail` throws `Xunit.Sdk.FailException`. However, in `WmlToHtmlConverterTests.AssertImageIsEqual` method, there is a try-catch block surrounding `Assert.Fail`, thus all tests passes despite the generated image from HTML not matching what is expected.

The following 2 tests are failing
HC007-Test-02 - due to incorrect additional spaces
HC010-Test-05 - due to font size differences