### PR TITLE
Convert nested and non-nested lists, numbered and bulleted, into XHTML ol and ul.

### DIFF
--- a/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
@@ -94,6 +94,14 @@ namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
 
         [Theory]
         [InlineData("HC023-Hyperlink.docx", "href=\"http://example.com/#anchor\"")]
+        [InlineData("HC003-Hebrew-02.docx", "<ul ", "<ol ")]
+        [InlineData("HC009-Test-04.docx", "<ul ", "<ol ")]
+        [InlineData("HC010-Test-05.docx", "<ul ")]
+        [InlineData("HC031-Complicated-Document.docx", "<ul ", "<ol ")]
+        [InlineData("HC006-Test-01.docx", "<ol ")]
+        [InlineData("HC012-Test-07.docx", "<ol ")]
+        [InlineData("HC048-Excerpt.docx", "<ol ")]
+        [InlineData("HC061-Hyperlink-in-Field.docx", "<ol ")]
         public async Task HC003_ContainsSubstring(string name, params string[] expectedSubstrings)
         {
             var sourceDir = new DirectoryInfo("../../../../TestFiles/");

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -6086,7 +6086,9 @@ listSeparator
         public static readonly XName html = xhtml + "html";
         public static readonly XName i = xhtml + "i";
         public static readonly XName img = xhtml + "img";
+        public static readonly XName li = xhtml + "li";
         public static readonly XName meta = xhtml + "meta";
+        public static readonly XName ol = xhtml + "ol";
         public static readonly XName p = xhtml + "p";
         public static readonly XName s = xhtml + "s";
         public static readonly XName span = xhtml + "span";
@@ -6098,6 +6100,7 @@ listSeparator
         public static readonly XName title = xhtml + "title";
         public static readonly XName tr = xhtml + "tr";
         public static readonly XName u = xhtml + "u";
+        public static readonly XName ul = xhtml + "ul";
     }
 
     public static class XhtmlNoNamespace


### PR DESCRIPTION
This preserves where the List were in the Word document, that is, paragraphs with `AbstractNumId`. Only the HTML structure is changed; there are no visual changes because the list style CSS is set to none.

Useful for further processing the HTML. 