### PR TITLE
Fix WmlToHtmlConverterTests failure message to show actual value instead of always showing 0

### DIFF
--- a/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
@@ -210,7 +210,7 @@ namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
 
                 if (allowedDiffInfo.DiffFileExists)
                 {
-                    var resultWithAllowedDiffPixelErrorCount = 0;
+                    var resultWithAllowedDiffPixelErrorCount = int.MaxValue;
                     foreach (var allowedDiffImage in allowedDiffInfo.ExistingDiffImageFilename)
                     {
                         var resultWithAllowedDiff = Compare.CalcDiff(actualFullPath, expectFullPath, allowedDiffImage, resizeOption, transparencyOptions: TransparencyOptions.CompareAlphaChannel);


### PR DESCRIPTION
Before this fix, the failure message is always

`Expected PixelErrorCount beyond 0 but was 0`

It reports actual value now

`Expected PixelErrorCount beyond 0 but was 1234`