### PR TITLE
Update WmlToHtmlConverter.cs to avoid null shadeType on shadings

### DIFF
--- a/OpenXmlPowerTools/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverter.cs
+++ b/OpenXmlPowerTools/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverter.cs
@@ -3146,7 +3146,7 @@ namespace Codeuctivity.OpenXmlPowerTools.OpenXMLWordprocessingMLToHtmlConverter
                 return;
             }
 
-            var shadeType = (string)shd.Attribute(W.val);
+            var shadeType = (string)shd.Attribute(W.val) ?? "clear";
             var color = (string)shd.Attribute(W.color);
             var fill = (string)shd.Attribute(W.fill);
             if (ShadeMapper.ContainsKey(shadeType))


### PR DESCRIPTION
On some shading, the val attibute can be missing and then the "CreateStyleFromShd" methode failed and throw an exception saying that the key cannot be null on a dictionary.