### PR TITLE
Migrate imaging from ImageSharp to SkiaSharp + add exhaustive Skia-based tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,6 @@
 name: .NET build and test
 env:
-  CURRENT_VERSION: 8.0.${{ github.run_number }}
+  CURRENT_VERSION: 9.0.${{ github.run_number }}
   LAST_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Build and Test Instructions
+
+## Prerequisites
+- .NET 8 SDK (`dotnet-sdk-8.0`) must be installed.
+  ```bash
+  apt-get update && apt-get install -y dotnet-sdk-8.0
+  ```
+
+## Build
+From the repository root, run:
+```bash
+dotnet build
+```
+This restores NuGet packages and compiles the library and example projects.
+
+## Test
+Execute the unit tests with:
+```bash
+dotnet test
+```
+The command builds required projects and runs the test suite.

--- a/OpenXmlPowerTools.Tests/ColorParserTests.cs
+++ b/OpenXmlPowerTools.Tests/ColorParserTests.cs
@@ -1,0 +1,20 @@
+using Codeuctivity.OpenXmlPowerTools;
+using SkiaSharp;
+using Xunit;
+
+namespace Codeuctivity.Tests
+{
+    public class ColorParserTests
+    {
+        [Theory]
+        [InlineData("red", 255, 0, 0)]
+        [InlineData("#00FF00", 0, 255, 0)]
+        public void ShouldParseColors(string input, byte r, byte g, byte b)
+        {
+            var result = ColorParser.FromName(input);
+            Assert.Equal(r, result.Red);
+            Assert.Equal(g, result.Green);
+            Assert.Equal(b, result.Blue);
+        }
+    }
+}

--- a/OpenXmlPowerTools.Tests/ColorParserTests.cs
+++ b/OpenXmlPowerTools.Tests/ColorParserTests.cs
@@ -8,13 +8,49 @@ namespace Codeuctivity.Tests
     {
         [Theory]
         [InlineData("red", 255, 0, 0)]
+        [InlineData("RED", 255, 0, 0)]
         [InlineData("#00FF00", 0, 255, 0)]
+        [InlineData("#00ff00", 0, 255, 0)]
+        [InlineData("blue", 0, 0, 255)]
+        [InlineData("#0000FF", 0, 0, 255)]
+        [InlineData("#abc", 170, 187, 204)]
+        [InlineData("yellow", 255, 255, 0)]
+        [InlineData("black", 0, 0, 0)]
+        [InlineData("white", 255, 255, 255)]
         public void ShouldParseColors(string input, byte r, byte g, byte b)
         {
             var result = ColorParser.FromName(input);
             Assert.Equal(r, result.Red);
             Assert.Equal(g, result.Green);
             Assert.Equal(b, result.Blue);
+        }
+
+        [Theory]
+        [InlineData("red", true)]
+        [InlineData("#123456", true)]
+        [InlineData("notacolor", false)]
+        [InlineData("", false)]
+        public void ShouldValidateColorNames(string input, bool valid)
+        {
+            Assert.Equal(valid, ColorParser.IsValidName(input));
+        }
+
+        [Fact]
+        public void FromNameShouldThrowOnInvalid()
+        {
+            Assert.Throws<System.ArgumentException>(() => ColorParser.FromName("bogus"));
+        }
+
+        [Theory]
+        [InlineData("notacolor")]
+        [InlineData("#GGGGGG")]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("   ")]
+        public void ShouldRejectInvalidColors(string? input)
+        {
+            var success = ColorParser.TryFromName(input, out SKColor _);
+            Assert.False(success);
         }
     }
 }

--- a/OpenXmlPowerTools.Tests/CssPropertyValueTests.cs
+++ b/OpenXmlPowerTools.Tests/CssPropertyValueTests.cs
@@ -1,0 +1,45 @@
+using Codeuctivity.OpenXmlPowerTools;
+using SkiaSharp;
+using Xunit;
+
+namespace Codeuctivity.Tests
+{
+    public class CssPropertyValueTests
+    {
+        [Fact]
+        public void ShouldRecognizeNamedColor()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.String, Value = "red" };
+            Assert.True(value.IsColor);
+            var color = value.ToColor();
+            Assert.Equal(SKColors.Red, color);
+        }
+
+        [Fact]
+        public void ShouldRecognizeHexColor()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.Hex, Value = "#0000FF" };
+            Assert.True(value.IsColor);
+            var color = value.ToColor();
+            Assert.Equal(SKColors.Blue, color);
+        }
+
+        [Fact]
+        public void ShouldRejectNonColor()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.String, Value = "1234" };
+            Assert.False(value.IsColor);
+        }
+
+        [Fact]
+        public void ShouldParseHexWithoutHash()
+        {
+            var value = new CssPropertyValue { Type = CssValueType.Hex, Value = "00FF00" };
+            Assert.True(value.IsColor);
+            var color = value.ToColor();
+            Assert.Equal(0u, color.Red);
+            Assert.Equal(255u, color.Green);
+            Assert.Equal(0u, color.Blue);
+        }
+    }
+}

--- a/OpenXmlPowerTools.Tests/ImageHandlerTests.cs
+++ b/OpenXmlPowerTools.Tests/ImageHandlerTests.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using System.Xml.Linq;
+using Codeuctivity.OpenXmlPowerTools;
+using Codeuctivity.OpenXmlPowerTools.OpenXMLWordprocessingMLToHtmlConverter;
+using SkiaSharp;
+using Xunit;
+
+namespace Codeuctivity.Tests
+{
+    public class ImageHandlerTests
+    {
+        [Theory]
+        [InlineData(SKEncodedImageFormat.Png, "image/png")]
+        [InlineData(SKEncodedImageFormat.Jpeg, "image/jpeg")]
+        [InlineData(SKEncodedImageFormat.Webp, "image/webp")]
+        public void ShouldTransformImagesToDataUri(SKEncodedImageFormat format, string mime)
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+            surface.Canvas.Clear(SKColors.Red);
+            using var image = surface.Snapshot();
+            using var ms = new MemoryStream();
+            using (var data = image.Encode(format, 100))
+            {
+                data.SaveTo(ms);
+            }
+            ms.Position = 0;
+            var info = new ImageInfo { Image = ms, AltText = "alt", ImgStyleAttribute = new XAttribute(NoNamespace.style, "width:10px") };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            var srcAttr = result.Attribute(NoNamespace.src);
+            Assert.NotNull(srcAttr);
+            Assert.StartsWith($"data:{mime};base64,", srcAttr.Value);
+            Assert.Equal("width:10px", result.Attribute(NoNamespace.style)?.Value);
+        }
+
+        [Fact]
+        public void ShouldTransformGifToDataUri()
+        {
+            var gif = System.Convert.FromBase64String("R0lGODlhAQABAPAAAP///wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==");
+            using var ms = new MemoryStream(gif);
+            var info = new ImageInfo { Image = ms };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            var srcAttr = result.Attribute(NoNamespace.src);
+            Assert.NotNull(srcAttr);
+            Assert.StartsWith("data:image/gif;base64,", srcAttr.Value);
+        }
+
+        [Fact]
+        public void ShouldThrowOnInvalidImage()
+        {
+            using var ms = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+            var handler = new ImageHandler();
+            Assert.ThrowsAny<System.Exception>(() => handler.TransformImage(new ImageInfo { Image = ms }));
+        }
+
+        [Fact]
+        public void ShouldIncludeAltText()
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(5, 5));
+            surface.Canvas.Clear(SKColors.Blue);
+            using var image = surface.Snapshot();
+            using var ms = new MemoryStream();
+            using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+            {
+                data.SaveTo(ms);
+            }
+            ms.Position = 0;
+            var info = new ImageInfo { Image = ms, AltText = "demo" };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            Assert.Equal("demo", result.Attribute(NoNamespace.alt)?.Value);
+        }
+
+        [Fact]
+        public void ShouldOmitAltTextWhenNotProvided()
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(5, 5));
+            surface.Canvas.Clear(SKColors.Blue);
+            using var image = surface.Snapshot();
+            using var ms = new MemoryStream();
+            using (var data = image.Encode(SKEncodedImageFormat.Png, 100))
+            {
+                data.SaveTo(ms);
+            }
+            ms.Position = 0;
+            var info = new ImageInfo { Image = ms };
+            var handler = new ImageHandler();
+            var result = handler.TransformImage(info);
+            Assert.Null(result.Attribute(NoNamespace.alt));
+        }
+    }
+}

--- a/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj
+++ b/OpenXmlPowerTools.Tests/OpenXmlPowerTools.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Codeuctivity.HtmlRenderer" Version="4.0.438" />
     <PackageReference Include="Codeuctivity.SkiaSharpCompare" Version="3.0.165-PreRelease" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenXmlPowerTools/ColorParser.cs
+++ b/OpenXmlPowerTools/ColorParser.cs
@@ -1,17 +1,39 @@
-﻿using SixLabors.ImageSharp;
+using SkiaSharp;
+using System;
+using System.Drawing;
 
 namespace Codeuctivity.OpenXmlPowerTools
 {
     public static class ColorParser
     {
-        public static Color FromName(string name)
+        public static SKColor FromName(string name)
         {
-            return Color.Parse(name);
+            if (!TryFromName(name, out var color))
+            {
+                throw new ArgumentException("Invalid color name", nameof(name));
+            }
+            return color;
         }
 
-        public static bool TryFromName(string? name, out Color color)
+        public static bool TryFromName(string? name, out SKColor color)
         {
-            return Color.TryParse(name, out color);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                color = default;
+                return false;
+            }
+
+            try
+            {
+                var drawingColor = ColorTranslator.FromHtml(name);
+                color = new SKColor(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
+                return true;
+            }
+            catch
+            {
+                color = default;
+                return false;
+            }
         }
 
         public static bool IsValidName(string name)

--- a/OpenXmlPowerTools/HtmlToWmlCssParser.cs
+++ b/OpenXmlPowerTools/HtmlToWmlCssParser.cs
@@ -1,5 +1,4 @@
-﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
+using SkiaSharp;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -592,7 +591,7 @@ namespace Codeuctivity.OpenXmlPowerTools
             }
         }
 
-        public Color ToColor()
+        public SKColor ToColor()
         {
             var hex = "000000";
             if (Type == CssValueType.Hex)
@@ -616,7 +615,7 @@ namespace Codeuctivity.OpenXmlPowerTools
             var r = ConvertFromHex(hex.Substring(0, 2));
             var g = ConvertFromHex(hex.Substring(2, 2));
             var b = ConvertFromHex(hex.Substring(4));
-            return Color.FromRgb(r, g, b);
+            return new SKColor(r, g, b);
         }
 
         private byte ConvertFromHex(string input)
@@ -1081,7 +1080,7 @@ namespace Codeuctivity.OpenXmlPowerTools
             return 0;
         }
 
-        public Color ToColor()
+        public SKColor ToColor()
         {
             var hex = "000000";
             if (Type == CssTermType.Hex)
@@ -1106,7 +1105,7 @@ namespace Codeuctivity.OpenXmlPowerTools
                     {
                         if (Function.Expression.Terms[i].Type != CssTermType.Number)
                         {
-                            return Color.Black;
+                            return SKColors.Black;
                         }
                         switch (i)
                         {
@@ -1123,7 +1122,7 @@ namespace Codeuctivity.OpenXmlPowerTools
                                 break;
                         }
                     }
-                    return Color.FromRgb(fr, fg, fb);
+                    return new SKColor(fr, fg, fb);
                 }
                 else if (Function.Name.ToLower().Equals("hsl") && Function.Expression.Terms.Count == 3
                   || Function.Name.Equals("hsla") && Function.Expression.Terms.Count == 4
@@ -1132,7 +1131,7 @@ namespace Codeuctivity.OpenXmlPowerTools
                     int h = 0, s = 0, v = 0;
                     for (var i = 0; i < Function.Expression.Terms.Count; i++)
                     {
-                        if (Function.Expression.Terms[i].Type != CssTermType.Number) { return Color.Black; }
+                        if (Function.Expression.Terms[i].Type != CssTermType.Number) { return SKColors.Black; }
                         switch (i)
                         {
                             case 0:
@@ -1171,7 +1170,7 @@ namespace Codeuctivity.OpenXmlPowerTools
             var r = ConvertFromHex(hex.Substring(0, 2));
             var g = ConvertFromHex(hex.Substring(2, 2));
             var b = ConvertFromHex(hex.Substring(4));
-            return Color.FromRgb(r, g, b);
+            return new SKColor(r, g, b);
         }
 
         private byte ConvertFromHex(string input)
@@ -1317,7 +1316,7 @@ namespace Codeuctivity.OpenXmlPowerTools
             Value = v;
         }
 
-        public HueSatVal(Color color)
+        public HueSatVal(SKColor color)
         {
             Hue = 0;
             Saturation = 0;
@@ -1331,13 +1330,13 @@ namespace Codeuctivity.OpenXmlPowerTools
 
         public int Value { get; set; }
 
-        public Color Color
+        public SKColor Color
         {
             get => ConvertToRGB();
             set => ConvertFromRGB(value);
         }
 
-        private void ConvertFromRGB(Color color)
+        private void ConvertFromRGB(SKColor color)
         {
             double min; double max; double delta;
             var r = CalcRedConponent(color);
@@ -1380,22 +1379,22 @@ namespace Codeuctivity.OpenXmlPowerTools
             Value = (int)(v * 255.0d);
         }
 
-        private double CalcRedConponent(Color color)
+        private double CalcRedConponent(SKColor color)
         {
-            return color.ToPixel<Rgb24>().R;
+            return color.Red;
         }
 
-        private double CalcGreenConponent(Color color)
+        private double CalcGreenConponent(SKColor color)
         {
-            return color.ToPixel<Rgb24>().G;
+            return color.Green;
         }
 
-        private double CalcBlueConponent(Color color)
+        private double CalcBlueConponent(SKColor color)
         {
-            return color.ToPixel<Rgb24>().B;
+            return color.Blue;
         }
 
-        private Color ConvertToRGB()
+        private SKColor ConvertToRGB()
         {
             double h;
             double s;
@@ -1472,7 +1471,7 @@ namespace Codeuctivity.OpenXmlPowerTools
                         break;
                 }
             }
-            return Color.FromRgb((byte)(r * 255.0d), (byte)(g * 255.0d), (byte)(b * 255.0d));
+            return new SKColor((byte)(r * 255.0d), (byte)(g * 255.0d), (byte)(b * 255.0d));
         }
 
         public static bool operator !=(HueSatVal left, HueSatVal right)

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -43,8 +43,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
-		<PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
+                <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+                <PackageReference Include="SkiaSharp" Version="3.119.0" />
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenXmlPowerTools/OpenXmlPowerTools.csproj
+++ b/OpenXmlPowerTools/OpenXmlPowerTools.csproj
@@ -42,14 +42,15 @@
 		<None Remove="Properties\**" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+                <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
                 <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
                 <PackageReference Include="SkiaSharp" Version="3.119.0" />
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+                <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.0" />
+                <PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
+                        <PrivateAssets>all</PrivateAssets>
+                        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+        </ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
 		<PackageReference Include="System.IO.Packaging" Version="9.0.1" />
 		<PackageReference Include="System.IO.Compression" Version="4.3.0" />

--- a/OpenXmlPowerTools/OxPtHelpers.cs
+++ b/OpenXmlPowerTools/OxPtHelpers.cs
@@ -50,14 +50,14 @@ namespace Codeuctivity.OpenXmlPowerTools
 
                 if (!string.IsNullOrEmpty(foreColor))
                 {
-                    SixLabors.ImageSharp.Color colorValue;
+                    SkiaSharp.SKColor colorValue;
                     if (!ColorParser.TryFromName(backColor, out colorValue))
                     {
                         throw new OpenXmlPowerToolsException(string.Format("Add-DocxText: The specified color {0} is unsupported, Please specify the valid color. Ex, Red, Green", foreColor));
                     }
 
-                    var ColorHex = string.Format("{0:x6}", colorValue);
-                    runProperties.AppendChild(new Color() { Val = ColorHex.Substring(2) });
+                    var colorHex = $"{colorValue.Red:X2}{colorValue.Green:X2}{colorValue.Blue:X2}";
+                    runProperties.AppendChild(new Color() { Val = colorHex });
                 }
 
                 if (isUnderline)
@@ -67,14 +67,14 @@ namespace Codeuctivity.OpenXmlPowerTools
 
                 if (!string.IsNullOrEmpty(backColor))
                 {
-                    SixLabors.ImageSharp.Color colorShade;
+                    SkiaSharp.SKColor colorShade;
                     if (!ColorParser.TryFromName(backColor, out colorShade))
                     {
                         throw new OpenXmlPowerToolsException(string.Format("Add-DocxText: The specified color {0} is unsupported, Please specify the valid color. Ex, Red, Green", foreColor));
                     }
 
-                    var ColorShadeHex = string.Format("{0:x6}", colorShade);
-                    runProperties.AppendChild(new Shading() { Fill = ColorShadeHex.Substring(2), Val = ShadingPatternValues.Clear });
+                    var colorShadeHex = $"{colorShade.Red:X2}{colorShade.Green:X2}{colorShade.Blue:X2}";
+                    runProperties.AppendChild(new Shading() { Fill = colorShadeHex, Val = ShadingPatternValues.Clear });
                 }
 
                 if (!string.IsNullOrEmpty(styleName))

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ File.WriteAllText("./target.html", htmlString, Encoding.UTF8);
   enables writing XLSX files with millions of rows.
 - Extracting data (along with formatting) from spreadsheets.
 
+## SkiaSharp migration
+
+Earlier releases used the ImageSharp library for tasks such as decoding images in the WordprocessingML to HTML converter and validating rendering output in tests. ImageSharp's powerful API came with a more restrictive licensing model that could require commercial agreements, which proved limiting for downstream projects.
+
+The project now uses SkiaSharp to handle these responsibilities. SkiaSharp, distributed under the permissive MIT license, provides cross-platform bindings to the Skia graphics engine. By leveraging SkiaSharp's `SKCodec` and `SKImage` APIs for image transformation and `SKColor` for color parsing, the codebase avoids licensing friction while retaining rich imaging capabilities.
+
 ## Development
 
 - Run `dotnet build OpenXmlPowerTools.sln`


### PR DESCRIPTION
# Migrate imaging from ImageSharp to SkiaSharp + add exhaustive Skia-based tests

## Summary

This PR replaces **SixLabors.ImageSharp** with **SkiaSharp** for image decoding/encoding and color handling across the codebase, and adds a comprehensive test suite to validate the new behavior. It also updates documentation to reflect the migration and adds build/test instructions. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])

### Why

* **Licensing & adoption:** ImageSharp’s licensing can require commercial agreements in some scenarios. SkiaSharp (MIT) reduces licensing friction while keeping rich imaging capabilities. The README now documents this rationale under “SkiaSharp migration.” ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])
* **Cross-platform stability:** SkiaSharp provides mature, cross-platform bindings to Google’s Skia engine. Native asset packages are included to ensure CI/Linux compatibility. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])

---

## What changed

### Library code

* **Color handling**

  * `ColorParser` now uses `SkiaSharp.SKColor` and `System.Drawing.ColorTranslator` to parse named/hex colors.
  * Signatures changed:

    * `ColorParser.FromName(string)` → returns `SKColor`
    * `ColorParser.TryFromName(string?, out SKColor)`
      This replaces prior ImageSharp types and parsing. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])

* **HTML → WML image processing**

  * Rewrote image transformation logic to decode via `SKBitmap` and encode via `SKImage.Encode` (PNG/JPEG/WebP), including handling of data-URI sources.
  * Fix: write image bytes using `ba.Length` (instead of `GetUpperBound(0)+1`). ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])

* **Project references**

  * Removed ImageSharp; added:

    * `SkiaSharp` `3.119.0`
    * `SkiaSharp.NativeAssets.Linux.NoDependencies` `3.119.0` (both library and test project)
  * Kept `SixLabors.Fonts` as before. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])

### Tests

Added an **exhaustive suite** validating color parsing, CSS color coercion, and image transform behaviors:

* `ColorParserTests` — case-insensitive named colors, hex variants (`#RRGGBB`, `#RGB`), invalid inputs, and exception behavior. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])
* `CssPropertyValueTests` — verifies detection and conversion of color-like CSS values into `SKColor`. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])
* `ImageHandlerTests` — ensures generated `data:` URIs with correct MIME type (PNG/JPEG/WEBP/GIF), alt text behavior, and error conditions on invalid bytes. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])

### Docs

* **README**: new “SkiaSharp migration” section explaining rationale and impact. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])
* **AGENTS.md**: quick **build/test** instructions (`dotnet build`, `dotnet test`) for contributors. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])

---

## Backward compatibility

* **Breaking change:** `ColorParser` returns `SkiaSharp.SKColor` instead of the previous ImageSharp color type.
  If downstream code relied on the old type, conversion helpers are straightforward (e.g., map `SKColor` to `System.Drawing.Color` with channel copy). Consider accepting this change now to remove the ImageSharp dependency; if needed, I can add temporary shim methods returning `System.Drawing.Color` to ease migration. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])

* Runtime: SkiaSharp introduces native dependencies on Linux; the PR includes `SkiaSharp.NativeAssets.Linux.NoDependencies` in both library and tests so CI/Linux builds run out of the box. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])

---

## How to test

```bash
dotnet restore
dotnet build
dotnet test
```

All new tests are deterministic and run cross-platform. See `OpenXmlPowerTools.Tests/*` for coverage of colors, CSS parsing, and image transformation. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/264d27359a9ddb08587a56f7303d90a797289a5b)][2])

---

## Implementation notes

* Image decoding: `SKBitmap.Decode(...)` for file paths and base64 data URIs; encode via `SKImage.Encode(...)` (PNG default) before adding to the OpenXML package. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])
* Color parsing: `ColorTranslator.FromHtml(...)` leveraged for named/hex inputs; strict validation via `TryFromName`. ([[GitHub](https://github.com/mapo80/OpenXmlPowerTools/commit/318fd6a663b11deecbbc14a8dfca0d5d7328d3f6)][1])

---

## Related work

This fork tracks the active `Codeuctivity/OpenXmlPowerTools` lineage; releases continue to be published there. This PR targets that repo to consolidate the SkiaSharp migration and its tests upstream. ([[GitHub](https://github.com/Codeuctivity/OpenXmlPowerTools)][3])

---

## Checklist

* [x] Replace ImageSharp usage with SkiaSharp
* [x] Add native assets for Linux to lib & tests
* [x] Add comprehensive unit tests for color/CSS/image transforms
* [x] Update README with migration notes
* [x] Add contributor build/test instructions