### PR TITLE
When removing smart tags, also remove smart tag properties (if present)

### DIFF
--- a/OpenXmlPowerTools.Tests/MarkupSimplifierTests.cs
+++ b/OpenXmlPowerTools.Tests/MarkupSimplifierTests.cs
@@ -12,8 +12,7 @@ namespace Codeuctivity.Tests
     {
         private const WordprocessingDocumentType DocumentType = WordprocessingDocumentType.Document;
 
-        private const string SmartTagDocumentTextValue = "The countries include Algeria, Botswana, and Sri Lanka.";
-
+        private const string SmartTagDocumentTextValue = "The countries include Algeria, Botswana, and Sri Lanka.  This is privileged information!";
         private const string SmartTagDocumentXmlString =
 @"<w:document xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
   <w:body>
@@ -45,7 +44,18 @@ namespace Codeuctivity.Tests
         </w:smartTag>
       </w:smartTag>
       <w:r>
-        <w:t>.</w:t>
+        <w:t xml:space=""preserve"">.  This is </w:t>
+			</w:r>
+			<w:smartTag w:uri=""schemas-workshare-com/workshare"" w:element=""confidentialinformationexposure"">
+				<w:smartTagPr>
+					<w:attr w:name=""TagType"" w:val=""5""/>
+				</w:smartTagPr>
+				<w:r>
+					<w:t>privileged</w:t>
+				</w:r>
+			</w:smartTag>
+			<w:r>
+				<w:t xml:space=""preserve""> information!</w:t>
       </w:r>
     </w:p>
   </w:body>

--- a/OpenXmlPowerTools/MarkupSimplifier.cs
+++ b/OpenXmlPowerTools/MarkupSimplifier.cs
@@ -191,14 +191,20 @@ namespace Codeuctivity.OpenXmlPowerTools
         {
             if (node is XElement element)
             {
-                if (simplifyMarkupSettings.RemoveSmartTags &&
-                    element.Name == W.smartTag)
+                if (simplifyMarkupSettings.RemoveSmartTags)
                 {
-                    return element
-                        .Elements()
-                        .Select(e =>
-                            RemoveCustomXmlAndContentControlsTransform(e,
-                                simplifyMarkupSettings));
+                    if (element.Name == W.smartTag)
+                    {
+                        return element
+                            .Elements()
+                            .Select(e =>
+                                RemoveCustomXmlAndContentControlsTransform(e,
+                                    simplifyMarkupSettings));
+                    }
+                    if (element.Name == W.smartTagPr)
+                    {
+                        return null;
+                    }
                 }
 
                 if (simplifyMarkupSettings.RemoveContentControls &&


### PR DESCRIPTION
Greetings! I'm the maintainer of another fork of OpenXmlPowerTools. I noticed you have what seems to be the most-frequently maintained fork, so I wondered if you would mind if I submitted some pull requests for several bug fixes I have made over the past several years?  In all cases I'll try to include appropriate unit tests so you can see exactly what triggers the buggy behavior.  If this PR looks okay I will submit several others.

In this case, the bug is caused by DOCX files containing (probably old, perhaps deprecated, but nevertheless encountered in real life!) "smart tags", specifically when those smart tags contain custom properties.  The MarkupSimplifier, when asked to remove smart tags from documents, removes them but does NOT remove the "properties" associated with them, which leaves the resulting document in a corrupt state. The fix is, when removing smart tags, to also check for smart tag properties and remove them at the same time.