### PR TITLE
Standardize test namespaces and syntax

### DIFF
--- a/OpenXmlPowerTools.Tests/ChartUpdaterTests.cs
+++ b/OpenXmlPowerTools.Tests/ChartUpdaterTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class CuTests
     {

--- a/OpenXmlPowerTools.Tests/ColorParserTests.cs
+++ b/OpenXmlPowerTools.Tests/ColorParserTests.cs
@@ -2,7 +2,7 @@ using Codeuctivity.OpenXmlPowerTools;
 using SkiaSharp;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class ColorParserTests
     {

--- a/OpenXmlPowerTools.Tests/CssPropertyValueTests.cs
+++ b/OpenXmlPowerTools.Tests/CssPropertyValueTests.cs
@@ -2,7 +2,7 @@ using Codeuctivity.OpenXmlPowerTools;
 using SkiaSharp;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class CssPropertyValueTests
     {

--- a/OpenXmlPowerTools.Tests/DocumentAssemblerTests.cs
+++ b/OpenXmlPowerTools.Tests/DocumentAssemblerTests.cs
@@ -1,18 +1,18 @@
 ﻿using Codeuctivity.OpenXmlPowerTools;
 using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using Xunit;
-using System.Globalization;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class DaTests
     {
@@ -126,7 +126,7 @@ namespace Codeuctivity.Tests
                 ms.Write(afterAssembling.DocumentByteArray, 0, afterAssembling.DocumentByteArray.Length);
                 using var wDoc = WordprocessingDocument.Open(ms, true);
                 var v = new OpenXmlValidator();
-                var valErrors = v.Validate(wDoc).Where(ve => !s_ExpectedErrors.Contains(ve.Description));
+                var valErrors = v.Validate(wDoc, TestContext.Current.CancellationToken).Where(ve => !s_ExpectedErrors.Contains(ve.Description));
 
                 var sb = new StringBuilder();
                 foreach (var item in valErrors.Select(r => r.Description).OrderBy(t => t).Distinct())
@@ -215,7 +215,7 @@ namespace Codeuctivity.Tests
                 ms.Write(afterAssembling.DocumentByteArray, 0, afterAssembling.DocumentByteArray.Length);
                 using var wDoc = WordprocessingDocument.Open(ms, true);
                 var v = new OpenXmlValidator();
-                var valErrors = v.Validate(wDoc).Where(ve => !s_ExpectedErrors.Contains(ve.Description));
+                var valErrors = v.Validate(wDoc, TestContext.Current.CancellationToken).Where(ve => !s_ExpectedErrors.Contains(ve.Description));
                 Assert.Empty(valErrors);
             }
 
@@ -515,8 +515,8 @@ namespace Codeuctivity.Tests
                 .StringConcatenate();
         }
 
-        private static readonly List<string> s_ExpectedErrors = new List<string>()
-        {
+        private static readonly List<string> s_ExpectedErrors =
+        [
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenHBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenVBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstColumn' attribute is not declared.",
@@ -531,6 +531,6 @@ namespace Codeuctivity.Tests
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:noVBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:oddHBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:oddVBand' attribute is not declared.",
-        };
+        ];
     }
 }

--- a/OpenXmlPowerTools.Tests/DocumentBuilderTests.cs
+++ b/OpenXmlPowerTools.Tests/DocumentBuilderTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class DbTests
     {
@@ -22,7 +22,7 @@ namespace Codeuctivity.Tests
             var sourceDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(sourceDocx.FullName), true),
+                new(new WmlDocument(sourceDocx.FullName), true),
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, sourceDocx.Name.Replace(".docx", "-processed-by-DocumentBuilder.docx")));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -36,9 +36,9 @@ namespace Codeuctivity.Tests
             var source2Docx = new FileInfo(Path.Combine(sourceDir.FullName, "DB002-Landscape-Section.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
-                new Source(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB002-Keep-Sections-Discard-Headers-And-Footers.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -52,9 +52,9 @@ namespace Codeuctivity.Tests
             var source2Docx = new FileInfo(Path.Combine(sourceDir.FullName, "DB002-Landscape-Section.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
-                new Source(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB003-Only-Default-Header.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -68,9 +68,9 @@ namespace Codeuctivity.Tests
             var source2Docx = new FileInfo(Path.Combine(sourceDir.FullName, "DB002-Landscape-Section.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
-                new Source(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB003-Only-Default-Header.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -84,9 +84,9 @@ namespace Codeuctivity.Tests
             var source2Docx = new FileInfo(Path.Combine(sourceDir.FullName, "DB002-Landscape-Section.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
-                new Source(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
-                new Source(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
+                new(new WmlDocument(source2Docx.FullName)) { KeepSections = true, DiscardHeadersAndFootersInKeptSections = true },
+                new(new WmlDocument(source1Docx.FullName)) { KeepSections = true },
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB005.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -103,7 +103,7 @@ namespace Codeuctivity.Tests
             // Create new document from 10 paragraphs starting at paragraph 5 of Source1.docx
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1.FullName), 5, 10, true),
+                new(new WmlDocument(source1.FullName), 5, 10, true),
             };
             var out1 = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB006-Out1.docx"));
             DocumentBuilder.BuildDocument(sources, out1.FullName);
@@ -111,33 +111,33 @@ namespace Codeuctivity.Tests
 
             // Create new document from paragraph 1, and paragraphs 5 through end of Source3.docx.
             // This effectively 'deletes' paragraphs 2-4
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source3.FullName), 0, 1, false),
                 new Source(new WmlDocument(source3.FullName), 4, false),
-            };
+            ];
             var out2 = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB006-Out2.docx"));
             DocumentBuilder.BuildDocument(sources, out2.FullName);
             Validate(out2);
 
             // Create a new document that consists of the entirety of Source1.docx and Source2.docx.  Use
             // the section information (headings and footers) from source1.
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1.FullName), true),
                 new Source(new WmlDocument(source2.FullName), false),
-            };
+            ];
             var out3 = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB006-Out3.docx"));
             DocumentBuilder.BuildDocument(sources, out3.FullName);
             Validate(out3);
 
             // Create a new document that consists of the entirety of Source1.docx and Source2.docx.  Use
             // the section information (headings and footers) from source2.
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1.FullName), false),
                 new Source(new WmlDocument(source2.FullName), true),
-            };
+            ];
             var out4 = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB006-Out4.docx"));
             DocumentBuilder.BuildDocument(sources, out4.FullName);
             Validate(out4);
@@ -145,11 +145,11 @@ namespace Codeuctivity.Tests
             // Create a new document that consists of the first 5 paragraphs of Source1.docx and the first
             // five paragraphs of Source2.docx.  This example returns a new WmlDocument, when you then can
             // serialize to a SharePoint document library, or use in some other interesting scenario.
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1.FullName), 0, 5, false),
                 new Source(new WmlDocument(source2.FullName), 0, 5, true),
-            };
+            ];
             var wmlOut5 = DocumentBuilder.BuildDocument(sources);
             var out5 = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB006-Out5.docx"));
 
@@ -167,10 +167,10 @@ namespace Codeuctivity.Tests
             var authorBio = new FileInfo(Path.Combine(sourceDir.FullName, "DB007-AuthorBiography.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(whitePaper.FullName), 0, 1, true),
-                new Source(new WmlDocument(paperAbstract.FullName), false),
-                new Source(new WmlDocument(authorBio.FullName), false),
-                new Source(new WmlDocument(whitePaper.FullName), 1, false),
+                new(new WmlDocument(whitePaper.FullName), 0, 1, true),
+                new(new WmlDocument(paperAbstract.FullName), false),
+                new(new WmlDocument(authorBio.FullName), false),
+                new(new WmlDocument(whitePaper.FullName), 1, false),
             };
             var assembledPaper = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB007-AssembledPaper.docx"));
             DocumentBuilder.BuildDocument(sources, assembledPaper.FullName);
@@ -187,7 +187,7 @@ namespace Codeuctivity.Tests
             // Delete all paragraphs with a specific style.
             using (var doc = WordprocessingDocument.Open(notes.FullName, false))
             {
-                sources = doc
+                sources = [.. doc
                     .MainDocumentPart
                     .GetXDocument()
                     .Root
@@ -206,8 +206,7 @@ namespace Codeuctivity.Tests
                     .Where(g => g.Key == true)
                     .Select(g => new Source(
                         new WmlDocument(notes.FullName), g.First().Index,
-                            g.Last().Index - g.First().Index + 1, true))
-                    .ToList();
+                            g.Last().Index - g.First().Index + 1, true))];
             }
             var newNotes = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB008-NewNotes.docx"));
             DocumentBuilder.BuildDocument(sources, newNotes.FullName);
@@ -247,7 +246,7 @@ namespace Codeuctivity.Tests
             var thisTestTempDir = new DirectoryInfo(Path.Combine(rootTempDir.FullName, testId));
             if (thisTestTempDir.Exists)
             {
-                Assert.True(false, "Duplicate test id: " + testId);
+                Assert.Fail("Duplicate test id: " + testId);
             }
             else
             {
@@ -296,8 +295,8 @@ namespace Codeuctivity.Tests
 
             var sources = new List<Source>()
             {
-                new Source(wmlDestDocument),
-                new Source(wmlSourceDocument, insertId),
+                new(wmlDestDocument),
+                new(wmlSourceDocument, insertId),
             };
 
             var outFi = new FileInfo(Path.Combine(tempDirFullName, "Output.docx"));
@@ -349,22 +348,21 @@ namespace Codeuctivity.Tests
                     pi.Index,
                     SectionIndex = sc,
                 });
-                documentList = zipped
+                documentList = [.. zipped
                     .GroupAdjacent(p => p.SectionIndex)
                     .Select(g => new DocumentInfo
                     {
                         DocumentNumber = g.Key,
                         Start = g.First().Index,
                         Count = g.Last().Index - g.First().Index + 1,
-                    })
-                    .ToList();
+                    })];
             }
             foreach (var doc in documentList)
             {
                 var fileName = string.Format("DB009-Section{0:000}.docx", doc.DocumentNumber);
                 var fiSection = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, fileName));
                 var documentSource = new List<Source> {
-                    new Source(new WmlDocument(spec.FullName), doc.Start, doc.Count, true)
+                    new(new WmlDocument(spec.FullName), doc.Start, doc.Count, true)
                 };
                 DocumentBuilder.BuildDocument(documentSource, fiSection.FullName);
                 Validate(fiSection);
@@ -422,10 +420,10 @@ namespace Codeuctivity.Tests
 
             var sources = new List<Source>()
             {
-                new Source(doc1, true),
-                new Source(new WmlDocument(insert01.FullName), "Liz"),
-                new Source(new WmlDocument(insert02.FullName), "Eric"),
-                new Source(new WmlDocument(front.FullName), "Front"),
+                new(doc1, true),
+                new(new WmlDocument(insert01.FullName), "Liz"),
+                new(new WmlDocument(insert02.FullName), "Eric"),
+                new(new WmlDocument(front.FullName), "Front"),
             };
             var out1 = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB010-Inserted.docx"));
             DocumentBuilder.BuildDocument(sources, out1.FullName);
@@ -441,8 +439,8 @@ namespace Codeuctivity.Tests
             var source2 = new FileInfo(Path.Combine(sourceDir.FullName, "DB011-Body-With-Shape.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1.FullName)),
-                new Source(new WmlDocument(source2.FullName)),
+                new(new WmlDocument(source1.FullName)),
+                new(new WmlDocument(source2.FullName)),
             };
             var processedDestDocx =
                 new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB011-Body-And-Header-With-Shapes.docx"));
@@ -461,7 +459,7 @@ namespace Codeuctivity.Tests
             var sourceDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(sourceDocx.FullName)),
+                new(new WmlDocument(sourceDocx.FullName)),
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName,
                 sourceDocx.Name.Replace(".docx", "-processed-by-DocumentBuilder.docx")));
@@ -481,7 +479,7 @@ namespace Codeuctivity.Tests
             var sourceDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(sourceDocx.FullName)),
+                new(new WmlDocument(sourceDocx.FullName)),
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName,
                 sourceDocx.Name.Replace(".docx", "-processed-by-DocumentBuilder.docx")));
@@ -513,8 +511,8 @@ namespace Codeuctivity.Tests
 
             var sources = new List<Source>()
             {
-                new Source(doc1, true),
-                new Source(new WmlDocument(source1.FullName), "Front"),
+                new(doc1, true),
+                new(new WmlDocument(source1.FullName), "Front"),
             };
             var processedDestDocx =
                 new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB012b-NumberingWithZeroIdWorks.docx"));
@@ -534,11 +532,11 @@ namespace Codeuctivity.Tests
                 "DB013a-Green-Heading1-Danish.docx"));
             List<Source> sources = null;
 
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1.FullName)),
                 new Source(new WmlDocument(source2.FullName)),
-            };
+            ];
             var processedDestDocx =
                 new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB013a-Colored-Heading1.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -566,11 +564,11 @@ namespace Codeuctivity.Tests
                 "DB013b-Blue-List-English.docx"));
             List<Source> sources = null;
 
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1.FullName)),
                 new Source(new WmlDocument(source2.FullName)),
-            };
+            ];
             var processedDestDocx =
                 new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB013b-Colored-List.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -593,7 +591,7 @@ namespace Codeuctivity.Tests
             var source = new FileInfo(Path.Combine(sourceDir.FullName, "DB014-WebExtensions.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source.FullName)),
+                new(new WmlDocument(source.FullName)),
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB014-WebExtensions.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -612,7 +610,7 @@ namespace Codeuctivity.Tests
             var source = new FileInfo(Path.Combine(sourceDir.FullName, "DB015-LatentStyles.docx"));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source.FullName)),
+                new(new WmlDocument(source.FullName)),
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "DB015-LatentStyles.docx"));
             DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
@@ -634,7 +632,7 @@ namespace Codeuctivity.Tests
             var sourceDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(sourceDocx.FullName), true),
+                new(new WmlDocument(sourceDocx.FullName), true),
             };
             var processedDestDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName,
                 sourceDocx.Name.Replace(".docx", "-processed-by-DocumentBuilder.docx")));
@@ -654,8 +652,8 @@ namespace Codeuctivity.Tests
 
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1.FullName)){KeepSections = true},
-                new Source(new WmlDocument(source2.FullName)){KeepSections = true, DiscardHeadersAndFootersInKeptSections = true},
+                new(new WmlDocument(source1.FullName)){KeepSections = true},
+                new(new WmlDocument(source2.FullName)){KeepSections = true, DiscardHeadersAndFootersInKeptSections = true},
             };
 
             var processedDestDocx = new FileInfo(Path.Combine(Path.Combine(TestUtil.TempDir.FullName), "DB017-ApplyHeaderAndFooterToAllDocs.docx"));
@@ -714,7 +712,7 @@ namespace Codeuctivity.Tests
             var thisTestTempDir = new DirectoryInfo(Path.Combine(rootTempDir.FullName, testId));
             if (thisTestTempDir.Exists)
             {
-                Assert.True(false, "Duplicate test id: " + testId);
+                Assert.Fail("Duplicate test id: " + testId);
             }
             else
             {
@@ -769,12 +767,12 @@ namespace Codeuctivity.Tests
                     sb.Append(item.Description).Append(Environment.NewLine);
                 }
                 var s = sb.ToString();
-                Assert.True(false, s);
+                Assert.Fail(s);
             }
         }
 
-        private static readonly List<string> s_ExpectedErrors = new List<string>()
-        {
+        private static readonly List<string> s_ExpectedErrors =
+        [
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenHBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenVBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstColumn' attribute is not declared.",
@@ -802,7 +800,7 @@ namespace Codeuctivity.Tests
             "http://schemas.microsoft.com/office/word/2008/9/12/wordml:",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:allStyles' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:customStyles' attribute is not declared.",
-        };
+        ];
 
         private void ValidateUniqueDocPrIds(FileInfo fi)
         {

--- a/OpenXmlPowerTools.Tests/FormattingAssemblerTests.cs
+++ b/OpenXmlPowerTools.Tests/FormattingAssemblerTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class FaTests
     {
@@ -49,7 +49,7 @@ namespace Codeuctivity.Tests
             var thisTestTempDir = new DirectoryInfo(Path.Combine(rootTempDir.FullName, testId));
             if (thisTestTempDir.Exists)
             {
-                Assert.True(false, "Duplicate test id: " + testId);
+                Assert.Fail("Duplicate test id: " + testId);
             }
             else
             {
@@ -100,12 +100,12 @@ namespace Codeuctivity.Tests
                     sb.Append(item.Description).Append(Environment.NewLine);
                 }
                 var s = sb.ToString();
-                Assert.True(false, s);
+                Assert.Fail(s);
             }
         }
 
-        private static readonly List<string> s_ExpectedErrors = new List<string>()
-        {
+        private static readonly List<string> s_ExpectedErrors =
+        [
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenHBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenVBand' attribute is not declared.",
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstColumn' attribute is not declared.",
@@ -135,6 +135,6 @@ namespace Codeuctivity.Tests
             "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:customStyles' attribute is not declared.",
             "The element has invalid child element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:ins'.",
             "The element has invalid child element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:del'.",
-        };
+        ];
     }
 }

--- a/OpenXmlPowerTools.Tests/HtmlToWmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/HtmlToWmlConverterTests.cs
@@ -25,7 +25,7 @@ using Xunit;
  * this module do not require the HtmlAgilityPack to run.
 *******************************************************************************************/
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class HwTests
     {

--- a/OpenXmlPowerTools.Tests/HtmlToWmlReadAsXElement.cs
+++ b/OpenXmlPowerTools.Tests/HtmlToWmlReadAsXElement.cs
@@ -26,7 +26,7 @@ using System.Xml.Linq;
 using HtmlAgilityPack;
 #endif
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class HtmlToWmlReadAsXElement
     {

--- a/OpenXmlPowerTools.Tests/ImageHandlerTests.cs
+++ b/OpenXmlPowerTools.Tests/ImageHandlerTests.cs
@@ -5,7 +5,7 @@ using Codeuctivity.OpenXmlPowerTools.OpenXMLWordprocessingMLToHtmlConverter;
 using SkiaSharp;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class ImageHandlerTests
     {

--- a/OpenXmlPowerTools.Tests/MarkupSimplifierTests.cs
+++ b/OpenXmlPowerTools.Tests/MarkupSimplifierTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class MarkupSimplifierTests
     {

--- a/OpenXmlPowerTools.Tests/MetricsGetterTests.cs
+++ b/OpenXmlPowerTools.Tests/MetricsGetterTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class MgTests
     {

--- a/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/AllowedDiffInfo.cs
+++ b/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/AllowedDiffInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
+﻿namespace OpenXmlPowerTools.Tests.OpenXMLWordprocessingMLToHtmlConverter
 {
     internal class AllowedDiffInfo
     {

--- a/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterHandlerTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterHandlerTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
+namespace OpenXmlPowerTools.Tests.OpenXMLWordprocessingMLToHtmlConverter
 {
     public class WmlToHtmlConverterHandlerTests
     {

--- a/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXMLWordprocessingMLToHtmlConverter/WmlToHtmlConverterTests.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
+namespace OpenXmlPowerTools.Tests.OpenXMLWordprocessingMLToHtmlConverter
 {
     public class WmlToHtmlConverterTests
     {
@@ -117,7 +117,7 @@ namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
             var sourceDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
             var settings = new WmlToHtmlConverterSettings(sourceDocx.FullName, new ImageHandler(), new TextDummyHandler(), new SymbolHandler(), new BreakHandler(), new FontHandler(), false);
 
-            var byteArray = await File.ReadAllBytesAsync(sourceDocx.FullName);
+            var byteArray = await File.ReadAllBytesAsync(sourceDocx.FullName, TestContext.Current.CancellationToken);
             using var memoryStream = new MemoryStream();
             memoryStream.Write(byteArray, 0, byteArray.Length);
             using var wDoc = WordprocessingDocument.Open(memoryStream, true);
@@ -243,7 +243,7 @@ namespace Codeuctivity.Tests.OpenXMLWordProcessingMLToHtmlConverter
                     Assert.Fail($"Expected PixelErrorCount less or equal {allowedPixelErrorCount} but was {result.PixelErrorCount}\nExpected {expectFullPath}\ndiffers to actual {actualFullPath}\n Diff is {allowedDiffInfo.NewDiffImageFileName} \nReplace {actualFullPath} with the new value or store the diff as {allowedDiffInfo.ExistingDiffImageFilename.First()}.");
                 }
             }
-            catch (System.Exception ex) when (!(ex is Xunit.Sdk.FailException))
+            catch (System.Exception ex) when (ex is not Xunit.Sdk.FailException)
             {
                 SaveToGithubActionsPickupTestresultsDirectory(actualFullPath, expectFullPath, allowedDiffInfo.NewDiffImageFileName);
             }

--- a/OpenXmlPowerTools.Tests/OpenXmlRegexTests.cs
+++ b/OpenXmlPowerTools.Tests/OpenXmlRegexTests.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class OpenXmlRegexTests
     {

--- a/OpenXmlPowerTools.Tests/PowerToolsBlockExtensionsTests.cs
+++ b/OpenXmlPowerTools.Tests/PowerToolsBlockExtensionsTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class PowerToolsBlockExtensionsTests : TestsBase
     {
@@ -52,7 +52,7 @@ namespace Codeuctivity.Tests
             // paragraph. This is caused by the GetXDocument method using the cached
             // XDocument, i.e., the annotation, rather reading the part's stream again.
             content = part.GetXDocument();
-            paragraphElements = content.Descendants(W.p).ToList();
+            paragraphElements = [.. content.Descendants(W.p)];
             Assert.Single(paragraphElements);
             Assert.Equal("First", paragraphElements[0].Value);
 
@@ -65,7 +65,7 @@ namespace Codeuctivity.Tests
             // Get content through the PowerTools in the exact same way as above.
             // We should now see both paragraphs.
             content = part.GetXDocument();
-            paragraphElements = content.Descendants(W.p).ToList();
+            paragraphElements = [.. content.Descendants(W.p)];
             Assert.Equal(2, paragraphElements.Count);
             Assert.Equal("First", paragraphElements[0].Value);
             Assert.Equal("Second", paragraphElements[1].Value);
@@ -114,7 +114,7 @@ namespace Codeuctivity.Tests
             // Get the part's content through the SDK. Having reloaded the root element,
             // we should still see both paragraphs.
             body = part.Document.Body;
-            paragraphs = body.Elements<Paragraph>().ToList();
+            paragraphs = [.. body.Elements<Paragraph>()];
             Assert.Equal(2, paragraphs.Count);
             Assert.Equal("Added through SDK", paragraphs[0].InnerText);
             Assert.Equal("Added through PowerTools", paragraphs[1].InnerText);

--- a/OpenXmlPowerTools.Tests/PowerToolsBlockTests.cs
+++ b/OpenXmlPowerTools.Tests/PowerToolsBlockTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class PowerToolsBlockTests : TestsBase
     {

--- a/OpenXmlPowerTools.Tests/PtUtilTests.cs
+++ b/OpenXmlPowerTools.Tests/PtUtilTests.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class PtUtilTests
     {

--- a/OpenXmlPowerTools.Tests/RevisionAccepterTests.cs
+++ b/OpenXmlPowerTools.Tests/RevisionAccepterTests.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class RaTests
     {

--- a/OpenXmlPowerTools.Tests/RevisionProcessorTests.cs
+++ b/OpenXmlPowerTools.Tests/RevisionProcessorTests.cs
@@ -3,7 +3,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class RpTests
     {

--- a/OpenXmlPowerTools.Tests/SmlCellFormatterTests.cs
+++ b/OpenXmlPowerTools.Tests/SmlCellFormatterTests.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class CfTests
     {

--- a/OpenXmlPowerTools.Tests/SmlToHtmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/SmlToHtmlConverterTests.cs
@@ -3,7 +3,7 @@ using DocumentFormat.OpenXml.Packaging;
 using System.IO;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class ShTests
     {

--- a/OpenXmlPowerTools.Tests/SpreadsheetWriterTests.cs
+++ b/OpenXmlPowerTools.Tests/SpreadsheetWriterTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class SwTests
     {
@@ -19,25 +19,21 @@ namespace Codeuctivity.Tests
             {
                 Worksheets = new WorksheetDfn[]
                 {
-                    new WorksheetDfn
-                    {
+                    new() {
                         Name = "MyFirstSheet",
                         TableName = "NamesAndRates",
                         ColumnHeadings = new CellDfn[]
                         {
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Name",
                                 Bold = true,
                             },
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Age",
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Left,
                             },
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Rate",
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Left,
@@ -45,38 +41,36 @@ namespace Codeuctivity.Tests
                         },
                         Rows = new RowDfn[]
                         {
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Eric",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 50,
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (decimal)45.00,
                                         FormatCode = "0.00",
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Bob",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 42,
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (decimal)78.00,
                                         FormatCode = "0.00",
@@ -100,18 +94,15 @@ namespace Codeuctivity.Tests
             {
                 Worksheets = new WorksheetDfn[]
                 {
-                    new WorksheetDfn
-                    {
+                    new() {
                         Name = "MyFirstSheet",
                         ColumnHeadings = new CellDfn[]
                         {
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "DataType",
                                 Bold = true,
                             },
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Value",
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Right,
@@ -119,185 +110,172 @@ namespace Codeuctivity.Tests
                         },
                         Rows = new RowDfn[]
                         {
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Boolean",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Boolean,
                                         Value = true,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Boolean",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Boolean,
                                         Value = false,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "String",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "A String",
                                         HorizontalCellAlignment = HorizontalCellAlignment.Right,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "int",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 100,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "int?",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 100,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "int? (is null)",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = null,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "uint",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 101,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "long",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = long.MaxValue,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "float",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (float)123.45,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "double",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 123.45,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "decimal",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (decimal)123.45,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "date (t:str)",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         Value = new DateTime(2012, 1, 8).ToOADate(),
                                         FormatCode= "mm-dd-yy",
                                         Bold = true,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "date (t:str)",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         Value = new DateTime(2012, 1, 9).ToOADate(),
                                         FormatCode= "mm-dd-yy",
                                         Bold = true,
@@ -305,15 +283,14 @@ namespace Codeuctivity.Tests
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "date (t:d)",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Date,
                                         Value = new DateTime(2012, 1, 11).ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff"),
                                     },
@@ -350,9 +327,9 @@ namespace Codeuctivity.Tests
             Assert.Empty(errors);
         }
 
-        private static readonly List<string> s_ExpectedErrors = new List<string>()
-        {
+        private static readonly List<string> s_ExpectedErrors =
+        [
             "The attribute 't' has invalid value 'd'. The Enumeration constraint failed.",
-        };
+        ];
     }
 }

--- a/OpenXmlPowerTools.Tests/StronglyTypedBlockTests.cs
+++ b/OpenXmlPowerTools.Tests/StronglyTypedBlockTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class StronglyTypedBlockTests : TestsBase
     {

--- a/OpenXmlPowerTools.Tests/TestUtil.cs
+++ b/OpenXmlPowerTools.Tests/TestUtil.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class TestUtil
     {

--- a/OpenXmlPowerTools.Tests/TestsBase.cs
+++ b/OpenXmlPowerTools.Tests/TestsBase.cs
@@ -3,7 +3,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.IO;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     /// <summary>
     /// Base class for unit tests providing utility methods.

--- a/OpenXmlPowerTools.Tests/UnicodeMapperTests.cs
+++ b/OpenXmlPowerTools.Tests/UnicodeMapperTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
-namespace Codeuctivity.Tests
+namespace OpenXmlPowerTools.Tests
 {
     public class UnicodeMapperTests
     {

--- a/OpenXmlPowerToolsExamples/DocumentBuilder01/DocumentBuilder01.cs
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder01/DocumentBuilder01.cs
@@ -21,45 +21,45 @@ namespace DocumentBuilder01
             // Create new document from 10 paragraphs starting at paragraph 5 of Source1.docx
             var sources = new List<Source>()
             {
-                new Source(new WmlDocument(source1), 5, 10, true),
+                new(new WmlDocument(source1), 5, 10, true),
             };
             DocumentBuilder.BuildDocument(sources, Path.Combine(tempDi.FullName, "Out1.docx"));
 
             // Create new document from paragraph 1, and paragraphs 5 through end of Source3.docx.
             // This effectively 'deletes' paragraphs 2-4
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source3), 0, 1, false),
                 new Source(new WmlDocument(source3), 4, false),
-            };
+            ];
             DocumentBuilder.BuildDocument(sources, Path.Combine(tempDi.FullName, "Out2.docx"));
 
             // Create a new document that consists of the entirety of Source1.docx and Source2.docx.  Use
             // the section information (headings and footers) from source1.
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1), true),
                 new Source(new WmlDocument(source2), false),
-            };
+            ];
             DocumentBuilder.BuildDocument(sources, Path.Combine(tempDi.FullName, "Out3.docx"));
 
             // Create a new document that consists of the entirety of Source1.docx and Source2.docx.  Use
             // the section information (headings and footers) from source2.
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1), false),
                 new Source(new WmlDocument(source2), true),
-            };
+            ];
             DocumentBuilder.BuildDocument(sources, Path.Combine(tempDi.FullName, "Out4.docx"));
 
             // Create a new document that consists of the first 5 paragraphs of Source1.docx and the first
             // five paragraphs of Source2.docx.  This example returns a new WmlDocument, when you then can
             // serialize to a SharePoint document library, or use in some other interesting scenario.
-            sources = new List<Source>()
-            {
+            sources =
+            [
                 new Source(new WmlDocument(source1), 0, 5, false),
                 new Source(new WmlDocument(source2), 0, 5, true),
-            };
+            ];
             var out5 = DocumentBuilder.BuildDocument(sources);
             out5.SaveAs(Path.Combine(tempDi.FullName, "Out5.docx"));  // save it to the file system, but we could just as easily done something
                                                                       // else with it.

--- a/OpenXmlPowerToolsExamples/DocumentBuilder02/DocumentBuilder02.cs
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder02/DocumentBuilder02.cs
@@ -30,13 +30,13 @@ internal class DocumentBuilderExample02
         // Insert an abstract and author biography into a white paper.
         List<Source> sources = null;
 
-        sources = new List<Source>()
-        {
+        sources =
+        [
             new Source(new WmlDocument("../../WhitePaper.docx"), 0, 1, true),
             new Source(new WmlDocument("../../Abstract.docx"), false),
             new Source(new WmlDocument("../../AuthorBiography.docx"), false),
             new Source(new WmlDocument("../../WhitePaper.docx"), 1, false),
-        };
+        ];
         DocumentBuilder.BuildDocument(sources, Path.Combine(tempDi.FullName, "AssembledPaper.docx"));
 
         // Delete all paragraphs with a specific style.
@@ -114,7 +114,7 @@ internal class DocumentBuilderExample02
         {
             var fileName = string.Format("Section{0:000}.docx", doc.DocumentNumber);
             var documentSource = new List<Source> {
-                new Source(new WmlDocument("../../Spec.docx"), doc.Start, doc.Count, true)
+                new(new WmlDocument("../../Spec.docx"), doc.Start, doc.Count, true)
             };
             DocumentBuilder.BuildDocument(documentSource, Path.Combine(tempDi.FullName, fileName));
         }

--- a/OpenXmlPowerToolsExamples/DocumentBuilder03/DocumentBuilder03.cs
+++ b/OpenXmlPowerToolsExamples/DocumentBuilder03/DocumentBuilder03.cs
@@ -43,10 +43,10 @@ internal class Program
         var outFileName = Path.Combine(tempDi.FullName, "Out.docx");
         var sources = new List<Source>()
             {
-                new Source(doc1, true),
-                new Source(new WmlDocument(@"..\..\Insert-01.docx"), "Liz"),
-                new Source(new WmlDocument(@"..\..\Insert-02.docx"), "Eric"),
-                new Source(new WmlDocument(@"..\..\FrontMatter.docx"), "Front"),
+                new(doc1, true),
+                new(new WmlDocument(@"..\..\Insert-01.docx"), "Liz"),
+                new(new WmlDocument(@"..\..\Insert-02.docx"), "Eric"),
+                new(new WmlDocument(@"..\..\FrontMatter.docx"), "Front"),
             };
         DocumentBuilder.BuildDocument(sources, outFileName);
     }

--- a/OpenXmlPowerToolsExamples/SpreadsheetWriter01/SpreadsheetWriter01.cs
+++ b/OpenXmlPowerToolsExamples/SpreadsheetWriter01/SpreadsheetWriter01.cs
@@ -16,25 +16,21 @@ namespace SpreadsheetWriter01
             {
                 Worksheets = new WorksheetDfn[]
                 {
-                    new WorksheetDfn
-                    {
+                    new() {
                         Name = "MyFirstSheet",
                         TableName = "NamesAndRates",
                         ColumnHeadings = new CellDfn[]
                         {
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Name",
                                 Bold = true,
                             },
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Age",
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Left,
                             },
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Rate",
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Left,
@@ -42,38 +38,36 @@ namespace SpreadsheetWriter01
                         },
                         Rows = new RowDfn[]
                         {
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Eric",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 50,
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (decimal)45.00,
                                         FormatCode = "0.00",
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Bob",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 42,
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (decimal)78.00,
                                         FormatCode = "0.00",

--- a/OpenXmlPowerToolsExamples/SpreadsheetWriter02/SpreadsheetWriter02.cs
+++ b/OpenXmlPowerToolsExamples/SpreadsheetWriter02/SpreadsheetWriter02.cs
@@ -16,18 +16,15 @@ namespace SpreadsheetWriter02
             {
                 Worksheets = new WorksheetDfn[]
                 {
-                    new WorksheetDfn
-                    {
+                    new() {
                         Name = "MyFirstSheet",
                         ColumnHeadings = new CellDfn[]
                         {
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "DataType",
                                 Bold = true,
                             },
-                            new CellDfn
-                            {
+                            new() {
                                 Value = "Value",
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Right,
@@ -35,171 +32,159 @@ namespace SpreadsheetWriter02
                         },
                         Rows = new RowDfn[]
                         {
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Boolean",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Boolean,
                                         Value = true,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "Boolean",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Boolean,
                                         Value = false,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "String",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "A String",
                                         HorizontalCellAlignment = HorizontalCellAlignment.Right,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "int",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 100,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "int?",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (int?)100,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "int? (is null)",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = null,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "uint",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (uint)101,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "long",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = long.MaxValue,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "float",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (float)123.45,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "double",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = 123.45,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.String,
                                         Value = "decimal",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Number,
                                         Value = (decimal)123.45,
                                     },
                                 }
                             },
-                            new RowDfn
-                            {
+                            new() {
                                 Cells = new CellDfn[]
                                 {
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Date,
                                         Value = new DateTime(2012, 1, 8),
                                         FormatCode = "mm-dd-yy",
                                     },
-                                    new CellDfn {
+                                    new() {
                                         CellDataType = CellDataType.Date,
                                         Value = new DateTime(2012, 1, 9),
                                         FormatCode = "mm-dd-yy",


### PR DESCRIPTION
Renames test namespaces from `Codeuctivity.Tests` to `OpenXmlPowerTools.Tests` (including the Wml-to-HTML subnamespace) to match the current project naming. Also modernizes test/example code with newer C# constructs (target-typed `new`, collection expressions, pattern updates), replaces `Assert.True(false, ...)` with `Assert.Fail(...)`, and passes cancellation tokens where supported (`OpenXmlValidator.Validate` and `File.ReadAllBytesAsync`) for cleaner, more consistent test code.